### PR TITLE
Fix misclassifications of torrents without resolution in title

### DIFF
--- a/connector/src/logic/classify.spec.ts
+++ b/connector/src/logic/classify.spec.ts
@@ -131,10 +131,6 @@ describe("classify", () => {
           tags: ["h265"],
         },
       },
-      {
-        raw: "this is not a valid name",
-        expected: null,
-      },
     ];
 
     for (const { raw, expected } of examples) {
@@ -264,7 +260,8 @@ describe("parseTorrentInfo", () => {
         expected: {
           bytes: 1029491916,
           cached: true,
-          mediaType: "movie",
+          mediaType: "season",
+          season: 8,
           originalResult: {
             name: "[RD+] Torrentio\nWEBRip",
             title:
@@ -273,7 +270,7 @@ describe("parseTorrentInfo", () => {
           },
           quality: "1080p",
           seeders: 3,
-          tags: ["cached"],
+          tags: ["cached", "h264", "web"],
           tracker: "1337x",
         },
       },

--- a/connector/src/logic/classify.ts
+++ b/connector/src/logic/classify.ts
@@ -30,10 +30,13 @@ export type Numbering =
   | { mediaType: "movie" };
 
 /** Classify a torrent based on its raw name. */
-export function classify(s: string): Classification | null {
+export function classify(s: string): Classification {
   const tokens = tokenize(s);
-  const quality = parseFromTokens(tokens, QUALITY_MATCHERS)[0] as Quality;
-  if (!quality) return null;
+  let quality = parseFromTokens(tokens, QUALITY_MATCHERS)[0] as Quality;
+  if (!quality) {
+    log.warn({ raw: s }, "Failed to parse quality. Assuming 1080p.");
+    quality = "1080p";
+  }
   const tags = parseFromTokens(tokens, TAG_MATCHERS) as Tag[];
 
   if (s.match(EPISODE_MATCHER)) {
@@ -83,16 +86,7 @@ export function classifyTorrentioResult(
     // The filename is often more descriptive than the torrent name, so prefer it
     const clF = classify(filenameLine);
     const clT = classify(torrentLine);
-
-    let quality = clF?.quality || clT?.quality;
-    if (!quality) {
-      log.warn(
-        { filenameLine, torrentLine },
-        "Failed to parse quality from Torrentio result. Assuming 1080p."
-      );
-      quality = "1080p";
-    }
-
+    const quality = clF?.quality || clT?.quality;
     const tagsT = (clT && clT.tags) || [];
     const tagsF = (clF && clF.tags) || [];
     const tags = [...tagsT, ...tagsF];

--- a/connector/src/logic/classify.ts
+++ b/connector/src/logic/classify.ts
@@ -66,19 +66,6 @@ function numberingFrom(
   return { mediaType: "movie" };
 }
 
-function qualityFrom(
-  filename: Classification | null,
-  torrent: Classification | null
-): Quality {
-  if (filename) return filename.quality;
-  if (torrent) return torrent.quality;
-  log.warn(
-    { filename, torrent },
-    "Failed to parse quality from Torrentio result. Assuming 1080p."
-  );
-  return "1080p";
-}
-
 /** Parse info from the raw Torrentio title data and build a complete TorrentInfo. */
 export function classifyTorrentioResult(
   tsr: TorrentioSearchResult
@@ -96,7 +83,16 @@ export function classifyTorrentioResult(
     // The filename is often more descriptive than the torrent name, so prefer it
     const clF = classify(filenameLine);
     const clT = classify(torrentLine);
-    const quality = qualityFrom(clF, clT);
+
+    let quality = clF?.quality || clT?.quality;
+    if (!quality) {
+      log.warn(
+        { filenameLine, torrentLine },
+        "Failed to parse quality from Torrentio result. Assuming 1080p."
+      );
+      quality = "1080p";
+    }
+
     const tagsT = (clT && clT.tags) || [];
     const tagsF = (clF && clF.tags) || [];
     const tags = [...tagsT, ...tagsF];


### PR DESCRIPTION
This fixes an issue causing torrents without a resolution in their title to be miscategorized in media type and tags.