### PR TITLE
QoL improvements

### DIFF
--- a/connector/README.md
+++ b/connector/README.md
@@ -51,5 +51,5 @@
 - [x] Summarize "all snatches complete" as count – redundant
 - [x] Auto-order TS imports
 - [ ] Don't throw in Overseerr Client
-- [ ] Fix quality parsing fallback when at least one quality is present on
+- [x] Fix quality parsing fallback when at least one quality is present on
       filename/torrent

--- a/connector/README.md
+++ b/connector/README.md
@@ -51,3 +51,5 @@
 - [x] Summarize "all snatches complete" as count – redundant
 - [x] Auto-order TS imports
 - [ ] Don't throw in Overseerr Client
+- [ ] Fix quality parsing fallback when at least one quality is present on
+      filename/torrent

--- a/connector/README.md
+++ b/connector/README.md
@@ -50,7 +50,9 @@
 - [x] Log tags in "snatched media" and "all snatches complete" msg
 - [x] Summarize "all snatches complete" as count – redundant
 - [x] Auto-order TS imports
-- [ ] Don't throw in Overseerr Client
+- [x] Don't throw in Overseerr Client
 - [x] Fix quality parsing fallback when at least one quality is present on
       filename/torrent
-- [ ] Pass name of call along to http calls for logging
+- [x] Pass name of call along to http calls for logging
+- [ ] Figure out sane way to do optionals in UberConf to not disrupt existing
+      users on upgrade

--- a/connector/README.md
+++ b/connector/README.md
@@ -53,3 +53,4 @@
 - [ ] Don't throw in Overseerr Client
 - [x] Fix quality parsing fallback when at least one quality is present on
       filename/torrent
+- [ ] Pass name of call along to http calls for logging

--- a/connector/src/clients/http.ts
+++ b/connector/src/clients/http.ts
@@ -1,10 +1,20 @@
-import { SafeParseReturnType } from "zod";
+import { SafeParseReturnType, ZodIssue } from "zod";
 
 import log from "../log";
 import { Result, Retryable, retry } from "../util/retry";
 
 // eslint-disable-next-line no-restricted-globals
 const nodeFetch = fetch;
+
+export type RespData<T> = RespSuccess<T> | RespFailure;
+export type RespSuccess<T> = {
+  success: true;
+  data: T;
+};
+export type RespFailure = {
+  success: false;
+  errors: (RequestError | ZodIssue)[];
+};
 
 type RequestableURL =
   | string
@@ -88,7 +98,7 @@ async function fetchJSON<T>(
   url: RequestableURL,
   schema: Validator<T>,
   opts: RequestInit
-) {
+): Promise<RespData<T>> {
   const o = {
     ...opts,
     headers: { Accept: "application/json", ...(opts.headers ?? {}) },

--- a/connector/src/clients/http.ts
+++ b/connector/src/clients/http.ts
@@ -34,11 +34,13 @@ function queryToStr(query: Record<string, any>) {
 
 /**
  * Make a request against an endpoint.
+ * @param desc a description of the task the request is performing
  * @param url the URL to fetch
  * @param opts options for the `fetch` request
  * @returns the response, or the errors
  */
 export function fetchResp(
+  desc: string,
   url: RequestableURL,
   opts: RequestInit
 ): Promise<Result<Response, RequestError>> {
@@ -48,7 +50,7 @@ export function fetchResp(
         ? url
         : `${url.url}?${queryToStr(url.query)}`;
 
-    log.debug({ u, opts }, "fetching");
+    log.debug({ u, opts }, `fetching: ${desc}`);
     const resp = await nodeFetch(u, opts);
     const { status, statusText } = resp;
 
@@ -89,12 +91,14 @@ export function fetchResp(
 
 /**
  * Make a request against an endpoint which returns JSON.
+ * @param desc a description of the task the request is performing
  * @param url the URL to fetch
  * @param schema the schema to use to parse the response
  * @param opts options for the `fetch` request
  * @returns the requested data, or the errors
  */
 async function fetchJSON<T>(
+  desc: string,
   url: RequestableURL,
   schema: Validator<T>,
   opts: RequestInit
@@ -104,7 +108,7 @@ async function fetchJSON<T>(
     headers: { Accept: "application/json", ...(opts.headers ?? {}) },
   };
 
-  const result = await fetchResp(url, o);
+  const result = await fetchResp(desc, url, o);
   if (!result.success) return result;
 
   const data = await result.data.json();
@@ -117,34 +121,39 @@ async function fetchJSON<T>(
 
 /**
  * Make a GET request against an endpoint.
+ * @param desc a description of the task the request is performing
  * @param url the URL to fetch
  * @param opts options for the `fetch` request
  * @returns the response, or the errors
  */
 export async function get(
+  desc: string,
   url: RequestableURL,
   opts: RequestInit = {}
 ): Promise<Result<Response, RequestError>> {
-  return fetchResp(url, { ...opts, method: "GET" });
+  return fetchResp(desc, url, { ...opts, method: "GET" });
 }
 
 /**
  * Make a GET request against an endpoint which returns JSON.
+ * @param desc a description of the task the request is performing
  * @param url the URL to fetch
  * @param schema the schema to use to parse the response
  * @param opts options for the `fetch` request
  * @returns the requested data, or the errors
  */
 export async function getJSON<T>(
+  desc: string,
   url: RequestableURL,
   schema: Validator<T>,
   opts: RequestInit = {}
 ) {
-  return fetchJSON(url, schema, { ...opts, method: "GET" });
+  return fetchJSON(desc, url, schema, { ...opts, method: "GET" });
 }
 
 /**
  * Make a POST request against an endpoint which returns JSON.
+ * @param desc a description of the task the request is performing
  * @param url the URL to fetch
  * @param body the body to send
  * @param schema the schema to use to parse the response
@@ -152,10 +161,11 @@ export async function getJSON<T>(
  * @returns the requested data, or the errors
  */
 export async function postJSON<T>(
+  desc: string,
   url: RequestableURL,
   body: BodyInit,
   schema: Validator<T>,
   opts: RequestInit = {}
 ) {
-  return fetchJSON(url, schema, { ...opts, method: "POST", body });
+  return fetchJSON(desc, url, schema, { ...opts, method: "POST", body });
 }

--- a/connector/src/clients/overseerr.ts
+++ b/connector/src/clients/overseerr.ts
@@ -59,16 +59,17 @@ export class OverseerrClient {
 
   constructor(private a: { host: string; apiKey: string }) {}
 
-  private async get<T>(path: string, schema: Schema<T>) {
+  private async get<T>(desc: string, path: string, schema: Schema<T>) {
     const url = `${this.a.host}/api/v1${path}`;
     const headers = { "X-Api-Key": this.a.apiKey };
-    return getJSON<T>(url, schema, { headers });
+    return getJSON<T>(desc, url, schema, { headers });
   }
 
   /** List approved Overseerr requests. */
   async getApprovedRequests() /*: Promise<RespData<RawRequest[]>> */ {
     const url = `/request?take=99999999&filter=approved`;
     return this.get(
+      "approved Overseerr requests",
       url,
       z.object({
         results: z.array(RAW_REQUEST_SCHEMA),
@@ -79,7 +80,11 @@ export class OverseerrClient {
   /** List all items on the Plex watchlist. */
   async getWatchlistItems() {
     const getPage = async (page: number) =>
-      this.get(`/discover/watchlist?page=${page}`, WATCHLIST_PAGE_SCHEMA);
+      this.get(
+        "page of Plex watchlist items",
+        `/discover/watchlist?page=${page}`,
+        WATCHLIST_PAGE_SCHEMA
+      );
 
     const first = await getPage(1);
     if (!first.success) return first;
@@ -133,6 +138,7 @@ export class OverseerrClient {
   async getMetadataSeason(tmdbID: number, season: number) {
     const url = `/tv/${tmdbID}/season/${season}`;
     const resp = await this.get(
+      "TV season metadata",
       url,
       z.object({
         episodes: z.array(
@@ -155,6 +161,7 @@ export class OverseerrClient {
   /** Get the metadata for a movie. */
   async getMetadataMovie(tmdbID: number) {
     return this.get(
+      "movie metadata",
       `/movie/${tmdbID}`,
       z.object({
         title: z.string(),
@@ -166,6 +173,7 @@ export class OverseerrClient {
 
   async getMetadataTV(tmdbID: number) {
     return this.get(
+      "TV show metadata",
       `/tv/${tmdbID}`,
       z.object({
         name: z.string(),

--- a/connector/src/clients/torrentio.ts
+++ b/connector/src/clients/torrentio.ts
@@ -28,10 +28,9 @@ export const torrentioSearchResultSchema = z.object({
 });
 export type TorrentioSearchResult = z.infer<typeof torrentioSearchResultSchema>;
 
-function get(cache: Cache<TorrentioSearchResult[]>, url: string) {
+function get(cache: Cache<TorrentioSearchResult[]>, desc: string, url: string) {
   return cache.get<ZodIssue | RequestError>(url, async () => {
-    log.debug({ url }, "fetching from Torrentio");
-    const result = await getJSON(url, torrentioSearchResultsSchema);
+    const result = await getJSON(desc, url, torrentioSearchResultsSchema);
     if (!result.success) return result;
 
     const unverified = result.data.streams;
@@ -64,7 +63,7 @@ export async function searchTorrentio(
   })();
 
   const url = `${TORRENTIO_HOST}/${debridPathPart}/stream/${typeAndSlug}.json`;
-  const r = await get(cache, url);
+  const r = await get(cache, "searching Torrentio", url);
   if (!r.success) {
     log.warn({ url, errors: r.errors }, "error fetching from Torrentio");
     return null;
@@ -74,6 +73,8 @@ export async function searchTorrentio(
 
 /** Snatch media into a Debrid account via Torrentio URL. */
 export function snatchViaURL(s: Snatchable) {
-  log.debug({ url: s.snatchURL }, "snatching via Torrentio");
-  return fetchResp(s.snatchURL, { method: "HEAD", headers });
+  return fetchResp("snatching via Torrentio", s.snatchURL, {
+    method: "HEAD",
+    headers,
+  });
 }

--- a/connector/src/logic/classify.spec.ts
+++ b/connector/src/logic/classify.spec.ts
@@ -263,10 +263,14 @@ describe("parseTorrentInfo", () => {
           },
         },
       },
+      // parse properly when neither torrent nor filename have quality
       {
         name: "[RD+] Torrentio\nWEBRip",
-        title:
-          "Homestead Rescue S08 Complete WEBRip x264-skorpion\nHomestead.Rescue.S08E01.Sweet.Homestead.Alabama.WEBRip.x264-skorpion.mp4\n👤 3 💾 981.8 MB ⚙️ 1337x",
+        title: stripIndent`
+          Homestead Rescue S08 Complete WEBRip x264-skorpion
+          Homestead.Rescue.S08E01.Sweet.Homestead.Alabama.WEBRip.x264-skorpion.mp4
+          👤 3 💾 981.8 MB ⚙️ 1337x
+        `,
         expected: {
           bytes: 1029491916,
           cached: true,
@@ -274,12 +278,71 @@ describe("parseTorrentInfo", () => {
           season: 8,
           originalResult: {
             name: "[RD+] Torrentio\nWEBRip",
-            title:
-              "Homestead Rescue S08 Complete WEBRip x264-skorpion\nHomestead.Rescue.S08E01.Sweet.Homestead.Alabama.WEBRip.x264-skorpion.mp4\n👤 3 💾 981.8 MB ⚙️ 1337x",
+            title: stripIndent`
+              Homestead Rescue S08 Complete WEBRip x264-skorpion
+              Homestead.Rescue.S08E01.Sweet.Homestead.Alabama.WEBRip.x264-skorpion.mp4
+              👤 3 💾 981.8 MB ⚙️ 1337x
+            `,
             url: "some url",
           },
           quality: "1080p",
           seeders: 3,
+          tags: ["cached", "h264", "web"],
+          tracker: "1337x",
+        },
+      },
+      // parse properly when torrent has quality but filename doesn't
+      {
+        name: "[AD+] Torrentio\nWEBRip",
+        title: stripIndent`
+          Mr Robot S01 Complete 4k
+          Mr.Robot.S01E01.eps1.0_hellofriend.mov.WEBRip.x264-fs0ci3ty.mp4
+          👤 1 💾 1.23 GB ⚙️ 1337x
+        `,
+        expected: {
+          bytes: 1320702443,
+          cached: true,
+          mediaType: "season",
+          season: 1,
+          originalResult: {
+            name: "[AD+] Torrentio\nWEBRip",
+            title: stripIndent`
+              Mr Robot S01 Complete 4k
+              Mr.Robot.S01E01.eps1.0_hellofriend.mov.WEBRip.x264-fs0ci3ty.mp4
+              👤 1 💾 1.23 GB ⚙️ 1337x
+            `,
+            url: "some url",
+          },
+          quality: "2160p",
+          seeders: 1,
+          tags: ["cached", "h264", "web"],
+          tracker: "1337x",
+        },
+      },
+      // parse properly when filename has quality but torrent doesn't
+      {
+        name: "[AD+] Torrentio\nWEBRip",
+        title: stripIndent`
+          Mr Robot S01 Complete
+          Mr.Robot.S01E01.eps1.0_hellofriend.mov.4k.WEBRip.x264-fs0ci3ty.mp4
+          👤 1 💾 1.23 GB ⚙️ 1337x
+        `,
+        expected: {
+          bytes: 1320702443,
+          cached: true,
+          mediaType: "season",
+          season: 1,
+          originalResult: {
+            name: "[AD+] Torrentio\nWEBRip",
+            title: stripIndent`
+              Mr Robot S01 Complete
+              Mr.Robot.S01E01.eps1.0_hellofriend.mov.4k.WEBRip.x264-fs0ci3ty.mp4
+              👤 1 💾 1.23 GB ⚙️ 1337x
+            `,
+            url: "some url",
+          },
+          quality: "2160p",
+          seeders: 1,
           tags: ["cached", "h264", "web"],
           tracker: "1337x",
         },

--- a/connector/src/logic/fetch.ts
+++ b/connector/src/logic/fetch.ts
@@ -77,7 +77,12 @@ export async function fetchOutstanding(a: {
   } = a;
 
   log.debug({ ignoreCache }, "fetching Overseerr requests");
-  const requested = await listOutstanding(a);
+  const resp = await listOutstanding(a);
+  if (!resp.success) {
+    log.error({ errors: resp.errors }, "failed to fetch Overseerr requests");
+    return;
+  }
+  const requested = resp.data;
   if (requested === "NO_NEW_REQUESTS") {
     log.debug("no new Overseerr requests, nothing to do");
     return;

--- a/connector/src/logic/list.ts
+++ b/connector/src/logic/list.ts
@@ -1,6 +1,7 @@
 import pLimit from "p-limit";
 import { pick } from "remeda";
 
+import { RespData } from "../clients/http";
 import {
   OverseerrClient,
   OverseerrRequest,
@@ -156,16 +157,17 @@ export async function listOutstanding(a: {
   ignoreCache: boolean;
   overseerrRequestConcurrency: number;
   searchBeforeReleaseDateMs: number;
-}): Promise<ToFetch[] | "NO_NEW_REQUESTS"> {
+}): Promise<RespData<ToFetch[] | "NO_NEW_REQUESTS">> {
   const { overseerrClient } = a;
   const ignoreCache = a.ignoreCache ?? false;
 
-  const requests =
-    await overseerrClient.getMetadataForRequestsAndWatchlistItems({
-      ignoreCache,
-    });
-  if (!requests) {
-    return "NO_NEW_REQUESTS";
+  const resp = await overseerrClient.getMetadataForRequestsAndWatchlistItems({
+    ignoreCache,
+  });
+  if (!resp.success) return resp;
+  const requests = resp.data;
+  if (!requests.length) {
+    return { success: true, data: "NO_NEW_REQUESTS" };
   }
 
   log.debug(
@@ -190,5 +192,5 @@ export async function listOutstanding(a: {
     },
     "built list of current Overseerr requests"
   );
-  return results.flat();
+  return { success: true, data: results.flat() };
 }

--- a/connector/src/logic/list.ts
+++ b/connector/src/logic/list.ts
@@ -146,6 +146,10 @@ export function listOverdue(
   return listOverdueTV(request, searchBeforeReleaseDateMs, now);
 }
 
+function leftPad2d(n: number): string {
+  return n.toString().padStart(2, "0");
+}
+
 /**
  * List the media that should be fetched for approved Radarr requests.
  * @param a.overseerrClient The Overseerr client to use
@@ -182,13 +186,11 @@ export async function listOutstanding(a: {
 
   log.debug(
     {
-      results: results.map((r) => ({
-        type: r.type,
-        imdbID: r.imdbID,
-        title: r.title,
-        season: "season" in r ? r.season : undefined,
-        episode: "episode" in r ? r.episode : undefined,
-      })),
+      results: results.map((r) => {
+        const s = "season" in r ? ` S${leftPad2d(r.season)}` : "";
+        const e = "episode" in r ? ` E${leftPad2d(r.episode)}` : "";
+        return `${r.imdbID}: ${r.title}${s}${e}`;
+      }),
     },
     "built list of current Overseerr requests"
   );

--- a/connector/src/util/retry.ts
+++ b/connector/src/util/retry.ts
@@ -86,11 +86,9 @@ export async function retry<T, E>(
       nextMaxDelay: delay,
     });
 
-    alog.debug("retry: calling fn with retry");
     // eslint-disable-next-line no-await-in-loop
     const outcome = await fn();
     if (outcome.state === "done") {
-      alog.debug("retryOpts: got result");
       return { success: true, data: outcome.data, errors };
     }
 
@@ -110,7 +108,6 @@ export async function retry<T, E>(
       Math.random() * delay, // full jitter
       maxDurationMs - (Date.now() - start) // one last try
     );
-    alog.debug("retry: retrying", { toSleep });
     // eslint-disable-next-line no-await-in-loop
     await sleep(toSleep);
     delay *= 2; // exponential backoff


### PR DESCRIPTION
-  Don't throw in Overseerr Client
-  Fix quality parsing fallback when at least one quality is present on filename/torrent
-  Pass name of call along to http calls for logging
- Bump version for new release