### PR TITLE
Fix default mount command to not bind to a specific named subdir

### DIFF
--- a/root/templates/rclone/start.sh
+++ b/root/templates/rclone/start.sh
@@ -2,7 +2,7 @@
 set -euxo pipefail
 
 # --config: location of the config file
-# mount provider:/torrents /media: connect to the source named [provider] in rclone.conf and mount the remote /torrents directory into local /media
+# mount provider:/ /media: connect to the source named [provider] in rclone.conf and mount the remote / directory into local /media
 # --allow-other: allow user `plex` to access our files
 # everything else are recommended settings for AllDebrid: https://help.alldebrid.com/en/faq/rclone-webdav
 
@@ -16,6 +16,4 @@ rclone \
 	--network-mode \
 	--read-only \
 	--vfs-cache-mode minimal \
-	mount \
-	provider:/torrents \
-	/media
+	mount provider:/ /media


### PR DESCRIPTION
This helps the mount as configured by default to work with various debrid hosts.