### PR TITLE
Use cache for Overseerr metadata requests

### DIFF
--- a/connector/package.json
+++ b/connector/package.json
@@ -1,6 +1,6 @@
 {
   "name": "connector",
-  "version": "0.3.4",
+  "version": "0.3.9",
   "description": "",
   "main": "index.js",
   "scripts": {

--- a/connector/src/clients/http.ts
+++ b/connector/src/clients/http.ts
@@ -1,5 +1,6 @@
 import { SafeParseReturnType, ZodIssue } from "zod";
 
+import { CommonError } from "../data/error";
 import log from "../log";
 import { Result, Retryable, retry } from "../util/retry";
 
@@ -13,7 +14,7 @@ export type RespSuccess<T> = {
 };
 export type RespFailure = {
   success: false;
-  errors: (RequestError | ZodIssue)[];
+  errors: CommonError[];
 };
 export type RequestError = {
   method: string;

--- a/connector/src/clients/http.ts
+++ b/connector/src/clients/http.ts
@@ -1,28 +1,12 @@
-import { SafeParseReturnType, ZodIssue } from "zod";
+import { SafeParseReturnType } from "zod";
 
-import { CommonError } from "../data/error";
 import log from "../log";
 import { Result, Retryable, retry } from "../util/retry";
 
+import { RequestError, RespData } from "./http.types";
+
 // eslint-disable-next-line no-restricted-globals
 const nodeFetch = fetch;
-
-export type RespData<T> = RespSuccess<T> | RespFailure;
-export type RespSuccess<T> = {
-  success: true;
-  data: T;
-};
-export type RespFailure = {
-  success: false;
-  errors: CommonError[];
-};
-export type RequestError = {
-  method: string;
-  url: string;
-  status: number;
-  statusText: string;
-  text: string;
-};
 
 type RequestableURL =
   | string

--- a/connector/src/clients/http.types.ts
+++ b/connector/src/clients/http.types.ts
@@ -1,0 +1,20 @@
+import { ZodIssue } from "zod";
+
+export type CommonError = Error | ZodIssue | RequestError;
+
+export type RespData<T> = RespSuccess<T> | RespFailure;
+export type RespSuccess<T> = {
+  success: true;
+  data: T;
+};
+export type RespFailure = {
+  success: false;
+  errors: CommonError[];
+};
+export type RequestError = {
+  method: string;
+  url: string;
+  status: number;
+  statusText: string;
+  text: string;
+};

--- a/connector/src/clients/overseerr.ts
+++ b/connector/src/clients/overseerr.ts
@@ -6,7 +6,8 @@ import z, { Schema } from "zod";
 import { Cache } from "../store/cache";
 import { secureHash } from "../util/hash";
 
-import { RespData, RespFailure, getJSON } from "./http";
+import { getJSON } from "./http";
+import { RespData, RespFailure } from "./http.types";
 import {
   MOVIE_METADATA_SCHEMA,
   MovieMetadata,

--- a/connector/src/clients/overseerr.ts
+++ b/connector/src/clients/overseerr.ts
@@ -1,62 +1,63 @@
+import { Level } from "level";
+import ms from "ms";
 import { isTruthy, map, pipe, sortBy } from "remeda";
-import z from "zod";
+import z, { Schema } from "zod";
 
+import { Cache } from "../store/cache";
 import { secureHash } from "../util/hash";
 
 import { RespData, RespFailure, getJSON } from "./http";
+import {
+  MOVIE_METADATA_SCHEMA,
+  MovieMetadata,
+  OverseerrRequest,
+  OverseerrRequestMovie,
+  OverseerrRequestTV,
+  RAW_REQUEST_SCHEMA,
+  RawRequest,
+  TVSeasonMetadata,
+  TVShowMetadata,
+  TV_SEASON_METADATA_SCHEMA,
+  TV_SHOW_METADATA_SCHEMA,
+  WATCHLIST_PAGE_SCHEMA,
+  WatchlistItem,
+} from "./overseerr.types";
 
-export type OverseerrRequest = OverseerrRequestTV | OverseerrRequestMovie;
-export type OverseerrRequestTV = {
-  type: "tv";
-  title: string;
-  imdbID: string;
-  seasons: {
-    season: number;
-    episodes: { episode: number; airDate: string }[];
-  }[];
-};
-export type OverseerrRequestMovie = {
-  type: "movie";
-  title: string;
-  imdbID: string;
-  releaseDate: string;
-};
-
-interface Schema<T> {
-  safeParse: (
-    input: unknown
-  ) => { success: true; data: T } | { success: false; error: z.ZodError };
-}
-
-const RAW_REQUEST_SCHEMA = z.object({
-  media: z.object({
-    mediaType: z.enum(["movie", "tv"]),
-    tmdbId: z.number(),
-  }),
-  seasons: z.array(z.object({ seasonNumber: z.number() })),
-});
-type RawRequest = z.infer<typeof RAW_REQUEST_SCHEMA>;
-
-const WATCHLIST_ITEM_SCHEMA = z.object({
-  title: z.string(),
-  mediaType: z.enum(["movie", "tv"]),
-  tmdbId: z.number(),
-});
-export type WatchlistItem = z.infer<typeof WATCHLIST_ITEM_SCHEMA>;
-
-const WATCHLIST_PAGE_SCHEMA = z.object({
-  page: z.number(),
-  totalPages: z.number(),
-  totalResults: z.number(),
-  results: z.array(WATCHLIST_ITEM_SCHEMA),
-});
+const METADATA_EXPIRY_MS = ms("6h");
 
 export class OverseerrClient {
   lastSeenRequestsHash: string | null = null;
 
   lastSeenWatchlistItemsHash: string | null = null;
 
-  constructor(private a: { host: string; apiKey: string }) {}
+  cacheMovie: Cache<MovieMetadata>;
+
+  cacheTVShow: Cache<TVShowMetadata>;
+
+  cacheTVSeason: Cache<TVSeasonMetadata>;
+
+  constructor(
+    private a: { host: string; apiKey: string; cacheDB: Level<string, string> }
+  ) {
+    this.cacheMovie = new Cache(
+      a.cacheDB,
+      "overseerrMetadataMovie",
+      METADATA_EXPIRY_MS,
+      MOVIE_METADATA_SCHEMA
+    );
+    this.cacheTVShow = new Cache(
+      a.cacheDB,
+      "overseerrMetadataTVShow",
+      METADATA_EXPIRY_MS,
+      TV_SHOW_METADATA_SCHEMA
+    );
+    this.cacheTVSeason = new Cache(
+      a.cacheDB,
+      "overseerrMetadataTVSeason",
+      METADATA_EXPIRY_MS,
+      TV_SEASON_METADATA_SCHEMA
+    );
+  }
 
   private async get<T>(desc: string, path: string, schema: Schema<T>) {
     const url = `${this.a.host}/api/v1${path}`;
@@ -70,9 +71,7 @@ export class OverseerrClient {
     return this.get(
       "approved Overseerr requests",
       url,
-      z.object({
-        results: z.array(RAW_REQUEST_SCHEMA),
-      })
+      z.object({ results: z.array(RAW_REQUEST_SCHEMA) })
     );
   }
 
@@ -133,20 +132,25 @@ export class OverseerrClient {
     return changed;
   }
 
+  /** Get the metadata for a movie. */
+  async getMetadataMovie(tmdbID: number) {
+    return this.cacheMovie.get(`${tmdbID}`, () =>
+      this.get("movie metadata", `/movie/${tmdbID}`, MOVIE_METADATA_SCHEMA)
+    );
+  }
+
+  /** Get the metadata for a TV show. */
+  async getMetadataTVShow(tmdbID: number) {
+    return this.cacheTVShow.get(`${tmdbID}`, () =>
+      this.get("TV show metadata", `/tv/${tmdbID}`, TV_SHOW_METADATA_SCHEMA)
+    );
+  }
+
   /** Get the metadata for a season of a TV show. */
-  async getMetadataSeason(tmdbID: number, season: number) {
+  async getMetadataTVSeason(tmdbID: number, season: number) {
     const url = `/tv/${tmdbID}/season/${season}`;
-    const resp = await this.get(
-      "TV season metadata",
-      url,
-      z.object({
-        episodes: z.array(
-          z.object({
-            episodeNumber: z.number(),
-            airDate: z.string().or(z.null()),
-          })
-        ),
-      })
+    const resp = await this.cacheTVSeason.get(`${tmdbID}_${season}`, () =>
+      this.get("TV season metadata", url, TV_SEASON_METADATA_SCHEMA)
     );
     if (!resp.success) return resp;
     // Some episodes lack air dates - we ignore them
@@ -157,32 +161,6 @@ export class OverseerrClient {
     return { success: true as const, data: withAirDates };
   }
 
-  /** Get the metadata for a movie. */
-  async getMetadataMovie(tmdbID: number) {
-    return this.get(
-      "movie metadata",
-      `/movie/${tmdbID}`,
-      z.object({
-        title: z.string(),
-        releaseDate: z.string(),
-        externalIds: z.object({ imdbId: z.string() }),
-      })
-    );
-  }
-
-  async getMetadataTV(tmdbID: number) {
-    return this.get(
-      "TV show metadata",
-      `/tv/${tmdbID}`,
-      z.object({
-        name: z.string(),
-        externalIds: z.object({ imdbId: z.string() }),
-        seasons: z.array(z.object({ seasonNumber: z.number() })),
-      })
-    );
-  }
-
-  // TODO: remove null
   /** Fetch metadata for all approved Overseerr requests and Plex watchlist items.
    * If there are no new requests since last time, return null. */
   async getMetadataForRequestsAndWatchlistItems(options: {
@@ -228,7 +206,7 @@ export class OverseerrClient {
         return { success: true as const, request: r };
       }
 
-      const metadata = await this.getMetadataTV(tmdbId);
+      const metadata = await this.getMetadataTVShow(tmdbId);
       if (!metadata.success) return metadata;
 
       const maybeSeasons = await Promise.all(
@@ -236,7 +214,7 @@ export class OverseerrClient {
           .filter((s) => s.seasonNumber > 0) // episodes in some Specials seasons lack air dates
           .map(async ({ seasonNumber }) => ({
             seasonNumber,
-            data: await this.getMetadataSeason(tmdbId, seasonNumber),
+            data: await this.getMetadataTVSeason(tmdbId, seasonNumber),
           }))
       );
       const seasons: {
@@ -295,7 +273,7 @@ export class OverseerrClient {
         return { success: true as const, request: r };
       }
 
-      const metadata = await this.getMetadataTV(tmdbId);
+      const metadata = await this.getMetadataTVShow(tmdbId);
       if (!metadata.success) return metadata;
 
       const maybeSeasons = await Promise.all(
@@ -303,7 +281,7 @@ export class OverseerrClient {
           .filter((s) => s.seasonNumber > 0) // episodes in some Specials seasons lack air dates
           .map(async ({ seasonNumber }) => ({
             seasonNumber,
-            data: await this.getMetadataSeason(tmdbId, seasonNumber),
+            data: await this.getMetadataTVSeason(tmdbId, seasonNumber),
           }))
       );
       const seasons: {

--- a/connector/src/clients/overseerr.types.ts
+++ b/connector/src/clients/overseerr.types.ts
@@ -1,0 +1,86 @@
+import z from "zod";
+
+/** A request made in Overseerr. */
+export type OverseerrRequest = OverseerrRequestTV | OverseerrRequestMovie;
+/** A request made in Overseerr for a TV show. */
+export type OverseerrRequestTV = {
+  type: "tv";
+  title: string;
+  imdbID: string;
+  seasons: {
+    season: number;
+    episodes: { episode: number; airDate: string }[];
+  }[];
+};
+/** A request made in Overseerr for a movie. */
+export type OverseerrRequestMovie = {
+  type: "movie";
+  title: string;
+  imdbID: string;
+  releaseDate: string;
+};
+
+/** A Zod schema which returns validated data or an error. */
+export interface Schema<T> {
+  safeParse: (
+    input: unknown
+  ) => { success: true; data: T } | { success: false; error: z.ZodError };
+}
+
+/** The schema for the request data from Overseerr. */
+export const RAW_REQUEST_SCHEMA = z.object({
+  media: z.object({
+    mediaType: z.enum(["movie", "tv"]),
+    tmdbId: z.number(),
+  }),
+  seasons: z.array(z.object({ seasonNumber: z.number() })),
+});
+/** The request data from Overseerr. */
+export type RawRequest = z.infer<typeof RAW_REQUEST_SCHEMA>;
+
+/** The schema for Plex watchlist items from Overseerr. */
+export const WATCHLIST_ITEM_SCHEMA = z.object({
+  title: z.string(),
+  mediaType: z.enum(["movie", "tv"]),
+  tmdbId: z.number(),
+});
+/** A Plex watchlist item from Overseerr. */
+export type WatchlistItem = z.infer<typeof WATCHLIST_ITEM_SCHEMA>;
+
+/** The schema for a page of Plex watchlist items from Overseerr. */
+export const WATCHLIST_PAGE_SCHEMA = z.object({
+  page: z.number(),
+  totalPages: z.number(),
+  totalResults: z.number(),
+  results: z.array(WATCHLIST_ITEM_SCHEMA),
+});
+
+/** The schema for the metadata for a movie from Overseerr. */
+export const MOVIE_METADATA_SCHEMA = z.object({
+  title: z.string(),
+  releaseDate: z.string(),
+  externalIds: z.object({ imdbId: z.string() }),
+});
+/** The metadata for a movie from Overseerr. */
+export type MovieMetadata = z.infer<typeof MOVIE_METADATA_SCHEMA>;
+
+/** The schema for the metadata for a TV show from Overseerr. */
+export const TV_SHOW_METADATA_SCHEMA = z.object({
+  name: z.string(),
+  externalIds: z.object({ imdbId: z.string() }),
+  seasons: z.array(z.object({ seasonNumber: z.number() })),
+});
+/** The metadata for a TV show from Overseerr. */
+export type TVShowMetadata = z.infer<typeof TV_SHOW_METADATA_SCHEMA>;
+
+/** The schema for the metadata for a season of a TV show from Overseerr. */
+export const TV_SEASON_METADATA_SCHEMA = z.object({
+  episodes: z.array(
+    z.object({
+      episodeNumber: z.number(),
+      airDate: z.string().or(z.null()),
+    })
+  ),
+});
+/** A season of a TV show from Overseerr. */
+export type TVSeasonMetadata = z.infer<typeof TV_SEASON_METADATA_SCHEMA>;

--- a/connector/src/clients/torrentio.ts
+++ b/connector/src/clients/torrentio.ts
@@ -1,6 +1,7 @@
 import { ZodIssue, z } from "zod";
 
 import { DebridCreds, buildDebridPathPart } from "../data/debrid";
+import { CommonError } from "../data/error";
 import log from "../log";
 import { ToFetch } from "../logic/list";
 import { Cache } from "../store/cache";
@@ -29,7 +30,7 @@ export const torrentioSearchResultSchema = z.object({
 export type TorrentioSearchResult = z.infer<typeof torrentioSearchResultSchema>;
 
 function get(cache: Cache<TorrentioSearchResult[]>, desc: string, url: string) {
-  return cache.get<ZodIssue | RequestError>(url, async () => {
+  return cache.get<CommonError>(url, async () => {
     const result = await getJSON(desc, url, torrentioSearchResultsSchema);
     if (!result.success) return result;
 

--- a/connector/src/clients/torrentio.ts
+++ b/connector/src/clients/torrentio.ts
@@ -1,13 +1,13 @@
-import { ZodIssue, z } from "zod";
+import { z } from "zod";
 
 import { DebridCreds, buildDebridPathPart } from "../data/debrid";
-import { CommonError } from "../data/error";
 import log from "../log";
 import { ToFetch } from "../logic/list";
 import { Cache } from "../store/cache";
 import { VERSION } from "../util/version";
 
-import { RequestError, fetchResp, getJSON } from "./http";
+import { fetchResp, getJSON } from "./http";
+import { CommonError } from "./http.types";
 
 const TORRENTIO_HOST = "https://torrentio.strem.fun";
 

--- a/connector/src/data/error.ts
+++ b/connector/src/data/error.ts
@@ -1,5 +1,0 @@
-import { ZodIssue } from "zod";
-
-import { RequestError } from "../clients/http";
-
-export type CommonError = Error | ZodIssue | RequestError;

--- a/connector/src/data/error.ts
+++ b/connector/src/data/error.ts
@@ -1,0 +1,5 @@
+import { ZodIssue } from "zod";
+
+import { RequestError } from "../clients/http";
+
+export type CommonError = Error | ZodIssue | RequestError;

--- a/connector/src/index.ts
+++ b/connector/src/index.ts
@@ -54,7 +54,11 @@ async function main() {
   const snatchExpiryMs = uberConf.connector.snatch.debridExpiry;
   const refreshWithinExpiryMs = uberConf.connector.snatch.refreshWithinExpiry;
 
+  const cacheDir = join(envConf.STORAGE_DIR, "cache");
+  const cacheDB = new Level(cacheDir);
+
   const overseerrClient = new OverseerrClient({
+    cacheDB,
     host: envConf.OVERSEERR_HOST,
     apiKey: overseerrAPIKey,
   });
@@ -62,8 +66,6 @@ async function main() {
   const databaseUrl = `file:${envConf.STORAGE_DIR}/db.sqlite`;
   const { client, db } = await connectDB(databaseUrl);
 
-  const cacheDir = join(envConf.STORAGE_DIR, "cache");
-  const cacheDB = new Level(cacheDir);
   const torrentioCache = new Cache<TorrentioSearchResult[]>(
     cacheDB,
     "torrentio",

--- a/connector/src/logic/list.spec.ts
+++ b/connector/src/logic/list.spec.ts
@@ -4,7 +4,7 @@ import { describe, expect, it } from "vitest";
 import {
   OverseerrRequestMovie,
   OverseerrRequestTV,
-} from "../clients/overseerr";
+} from "../clients/overseerr.types";
 import { Given } from "../test/given";
 
 import {

--- a/connector/src/logic/list.ts
+++ b/connector/src/logic/list.ts
@@ -2,12 +2,12 @@ import pLimit from "p-limit";
 import { pick } from "remeda";
 
 import { RespData } from "../clients/http";
+import { OverseerrClient } from "../clients/overseerr";
 import {
-  OverseerrClient,
   OverseerrRequest,
   OverseerrRequestMovie,
   OverseerrRequestTV,
-} from "../clients/overseerr";
+} from "../clients/overseerr.types";
 import log from "../log";
 
 import { ContainedMediaType } from "./rank";

--- a/connector/src/logic/list.ts
+++ b/connector/src/logic/list.ts
@@ -1,7 +1,7 @@
 import pLimit from "p-limit";
 import { pick } from "remeda";
 
-import { RespData } from "../clients/http";
+import { RespData } from "../clients/http.types";
 import { OverseerrClient } from "../clients/overseerr";
 import {
   OverseerrRequest,


### PR DESCRIPTION
Fetching metadata for shows/movies happens frequently but can be slow on some machines. Cache this data for a reasonable amount of time.