### PR TITLE
Ignore validation errors for watchlist metadata

### DIFF
--- a/connector/package.json
+++ b/connector/package.json
@@ -17,6 +17,7 @@
     "@prisma/client": "^5.2.0",
     "@trpc/server": "^10.38.1",
     "bytes": "^3.1.2",
+    "dotenv": "^16.3.1",
     "execa": "^5",
     "fastify": "^4.22.2",
     "ini": "^4.1.1",

--- a/connector/pnpm-lock.yaml
+++ b/connector/pnpm-lock.yaml
@@ -14,6 +14,9 @@ dependencies:
   bytes:
     specifier: ^3.1.2
     version: 3.1.2
+  dotenv:
+    specifier: ^16.3.1
+    version: 16.3.1
   execa:
     specifier: ^5
     version: 5.0.0
@@ -1158,6 +1161,11 @@ packages:
     dependencies:
       esutils: 2.0.3
     dev: true
+
+  /dotenv@16.3.1:
+    resolution: {integrity: sha512-IPzF4w4/Rd94bA9imS68tZBaYyBWSCE47V1RGuMrB94iyTOIEwRmVL2x/4An+6mETpLrKJ5hQkB8W4kFAadeIQ==}
+    engines: {node: '>=12'}
+    dev: false
 
   /end-of-stream@1.4.4:
     resolution: {integrity: sha512-+uw1inIHVPQoaVuHzRyXd21icM+cnt4CzD5rW+NC1wjOUSTOs+Te7FOv7AhN7vS9x/oIyhLP5PR1H+phQAHu5Q==}

--- a/connector/src/clients/http.types.ts
+++ b/connector/src/clients/http.types.ts
@@ -1,6 +1,13 @@
 import { ZodIssue } from "zod";
 
-export type CommonError = Error | ZodIssue | RequestError;
+export type CommonError = (Error | ZodIssue | RequestError | Object) & {
+  errorCategory:
+    | "network" // network error
+    | "server" // 5xx, or e.g. missing redirect header
+    | "client" // 4xx
+    | "validation" // zod validation error
+    | "internal"; // internal error
+};
 
 export type RespData<T> = RespSuccess<T> | RespFailure;
 export type RespSuccess<T> = {
@@ -12,9 +19,17 @@ export type RespFailure = {
   errors: CommonError[];
 };
 export type RequestError = {
+  errorCategory: "network" | "server" | "client";
   method: string;
   url: string;
   status: number;
   statusText: string;
   text: string;
 };
+
+/** Flatten a list of results with nested errors into a list of errors. */
+export function justErrors(
+  datas: ({ success: true } | RespFailure)[]
+): CommonError[] {
+  return datas.flatMap((d) => (d.success ? [] : d.errors));
+}

--- a/connector/src/clients/overseerr.ts
+++ b/connector/src/clients/overseerr.ts
@@ -1,6 +1,6 @@
 import { Level } from "level";
 import ms from "ms";
-import { isTruthy, map, partition, pipe, sortBy } from "remeda";
+import { isTruthy, map, pipe, sortBy } from "remeda";
 import z, { Schema } from "zod";
 
 import log from "../log";
@@ -8,7 +8,7 @@ import { Cache } from "../store/cache";
 import { secureHash } from "../util/hash";
 
 import { getJSON } from "./http";
-import { CommonError, RespData, RespFailure, justErrors } from "./http.types";
+import { CommonError, RespData, RespFailure } from "./http.types";
 import {
   MOVIE_METADATA_SCHEMA,
   MovieMetadata,

--- a/connector/src/index.ts
+++ b/connector/src/index.ts
@@ -1,5 +1,6 @@
 import { join } from "path";
 
+import "dotenv/config";
 import { PrismaClient } from "@prisma/client";
 import execa from "execa";
 import { Level } from "level";

--- a/connector/src/store/cache.ts
+++ b/connector/src/store/cache.ts
@@ -1,7 +1,7 @@
 import { Level } from "level";
 import ms from "ms";
 import { Logger } from "pino";
-import { ZodSchema, object, z } from "zod";
+import { ZodSchema, z } from "zod";
 
 import { CommonError } from "../clients/http.types";
 import log from "../log";


### PR DESCRIPTION
This keeps an error in one piece of watchlist metadata from preventing anything else from using the entire watchlist.